### PR TITLE
Port midpoint tests from turf.js

### DIFF
--- a/test/components/midpoint_test.dart
+++ b/test/components/midpoint_test.dart
@@ -1,12 +1,21 @@
 import 'package:test/test.dart';
+import 'package:turf/distance.dart';
 import 'package:turf/helpers.dart';
 import 'package:turf/midpoint.dart';
 
+void checkLatLngInRange(Point result) {
+  _lngRange(num lng) => lng >= -180 && lng <= 180;
+  _latRange(num lat) => lat >= -90 && lat <= 90;
+
+  expect(_lngRange(result.coordinates.lng), true,
+      reason: 'Longitude of ${result.coordinates.lng} out of range');
+  expect(_latRange(result.coordinates.lat), true,
+      reason: 'Latitude of ${result.coordinates.lat} out of range');
+}
+
 main() {
-  test('midpoint', () {
-    _lngRange(num lng) => lng >= -180 && lng <= 180;
-    _latRange(num lat) => lat >= -90 && lat <= 90;
-    var result = midpoint(
+  test('simple midpoint', () {
+    Point result = midpoint(
       Point(
         coordinates: Position.named(
           lat: -33.4312226,
@@ -20,8 +29,139 @@ main() {
         ),
       ),
     );
-    print(result.coordinates.join(', '));
-    expect(_lngRange(result.coordinates.lng), true);
-    expect(_latRange(result.coordinates.lat), true);
+    checkLatLngInRange(result);
+  });
+
+  test('midpoint -- horizontal equator', () {
+    Point pt1 = Point(
+      coordinates: Position.named(
+        lng: 0,
+        lat: 0,
+      ),
+    );
+    Point pt2 = Point(
+      coordinates: Position.named(
+        lng: 10,
+        lat: 0,
+      ),
+    );
+    Point result = midpoint(pt1, pt2);
+
+    checkLatLngInRange(result);
+  });
+
+  test('midpoint -- vertical from equator', () {
+    Point pt1 = Point(
+      coordinates: Position.named(
+        lng: 0,
+        lat: 0,
+      ),
+    );
+    Point pt2 = Point(
+      coordinates: Position.named(
+        lng: 0,
+        lat: 10,
+      ),
+    );
+
+    Point result = midpoint(pt1, pt2);
+
+    checkLatLngInRange(result);
+    expect(
+        distance(pt1, result).toStringAsFixed(6) ==
+            distance(pt2, result).toStringAsFixed(6),
+        true);
+  });
+
+  test('midpoint -- vertical to equator', () {
+    Point pt1 = Point(
+      coordinates: Position.named(
+        lng: 0,
+        lat: 10,
+      ),
+    );
+    Point pt2 = Point(
+      coordinates: Position.named(
+        lng: 0,
+        lat: 0,
+      ),
+    );
+
+    Point result = midpoint(pt1, pt2);
+
+    checkLatLngInRange(result);
+    expect(
+        distance(pt1, result).toStringAsFixed(6) ==
+            distance(pt2, result).toStringAsFixed(6),
+        true);
+  });
+
+  test('midpoint -- diagonal back over equator', () {
+    Point pt1 = Point(
+      coordinates: Position.named(
+        lng: -1,
+        lat: 10,
+      ),
+    );
+    Point pt2 = Point(
+      coordinates: Position.named(
+        lng: 1,
+        lat: -1,
+      ),
+    );
+
+    Point result = midpoint(pt1, pt2);
+
+    checkLatLngInRange(result);
+    expect(
+        distance(pt1, result).toStringAsFixed(6) ==
+            distance(pt2, result).toStringAsFixed(6),
+        true);
+  });
+
+  test('midpoint -- diagonal forward over equator', () {
+    Point pt1 = Point(
+      coordinates: Position.named(
+        lng: -5,
+        lat: -1,
+      ),
+    );
+    Point pt2 = Point(
+      coordinates: Position.named(
+        lng: 5,
+        lat: 10,
+      ),
+    );
+
+    Point result = midpoint(pt1, pt2);
+
+    checkLatLngInRange(result);
+    expect(
+        distance(pt1, result).toStringAsFixed(6) ==
+            distance(pt2, result).toStringAsFixed(6),
+        true);
+  });
+
+  test('midpoint -- long distance', () {
+    Point pt1 = Point(
+      coordinates: Position.named(
+        lng: 22.5,
+        lat: 21.94304553343818,
+      ),
+    );
+    Point pt2 = Point(
+      coordinates: Position.named(
+        lng: 92.10937499999999,
+        lat: 46.800059446787316,
+      ),
+    );
+
+    Point result = midpoint(pt1, pt2);
+
+    checkLatLngInRange(result);
+    expect(
+        distance(pt1, result).toStringAsFixed(6) ==
+            distance(pt2, result).toStringAsFixed(6),
+        true);
   });
 }


### PR DESCRIPTION
Midpoint tests taken from https://github.com/Turfjs/turf commit SHA
23d5cb91d77e0c1e2e903a2252f525797f1d0d09 (the current `master` commit as of writing)

Spawned by test failure referenced in issue  #3 

Basically a direct port of the turf.js tests, with the addition of the existing lat/lng in range check the existing turf_dart test had.

Two of these tests still fail, but perhaps that points to an implementation bug in `midpoint`. It seemed starting with the turf.js tests would help identify if there was in fact a bug in the implementation.