### PR TITLE
Add tests and convert modulo to remainder

### DIFF
--- a/lib/src/bearing.dart
+++ b/lib/src/bearing.dart
@@ -24,9 +24,8 @@ num bearing(Point start, Point end, {bool calcFinal = false}) =>
 
 num calculateFinalBearingRaw(Position start, Position end) {
   // Swap start & end
-  var bear = bearingRaw(end, start);
-  bear = (bear + 180) % 360;
-  return bear;
+  num reverseBearing = bearingRaw(end, start) + 180;
+  return reverseBearing.remainder(360);
 }
 
 num calculateFinalBearing(Point start, Point end) =>

--- a/lib/src/helpers.dart
+++ b/lib/src/helpers.dart
@@ -77,7 +77,8 @@ num round(value, [precision = 0]) {
     throw Exception("precision must be a positive number");
   }
   num multiplier = pow(10, precision);
-  return round(value * multiplier) / multiplier;
+  num result = (value * multiplier);
+  return result.round() / multiplier;
 }
 
 num radiansToLength(num radians, [Unit unit = Unit.kilometers]) {

--- a/lib/src/helpers.dart
+++ b/lib/src/helpers.dart
@@ -110,12 +110,12 @@ num bearingToAzimuth(num bearing) {
 }
 
 num radiansToDegrees(num radians) {
-  num degrees = radians % (2 * pi);
+  num degrees = radians.remainder(2 * pi);
   return degrees * 180 / pi;
 }
 
 num degreesToRadians(num degrees) {
-  num radians = degrees % 360;
+  num radians = degrees.remainder(360);
   return radians * pi / 180;
 }
 

--- a/lib/src/helpers.dart
+++ b/lib/src/helpers.dart
@@ -102,7 +102,7 @@ num lengthToDegrees(num distance, [Unit unit = Unit.kilometers]) {
 }
 
 num bearingToAzimuth(num bearing) {
-  num angle = bearing % 360;
+  num angle = bearing.remainder(360);
   if (angle < 0) {
     angle += 360;
   }

--- a/lib/src/midpoint.dart
+++ b/lib/src/midpoint.dart
@@ -5,9 +5,7 @@ import 'geojson.dart';
 
 Position midpointRaw(Position point1, Position point2) {
   var dist = distanceRaw(point1, point2);
-  print(dist);
   var heading = bearingRaw(point1, point2);
-  print(heading);
   var midpoint = destinationRaw(point1, dist / 2, heading);
 
   return midpoint;

--- a/test/components/destination_test.dart
+++ b/test/components/destination_test.dart
@@ -5,6 +5,9 @@ import 'package:turf/distance.dart';
 import 'package:turf/helpers.dart';
 
 main() {
+  num defaultBearing = 180;
+  num defaultDistance = 100;
+
   test('destination', () {
     var start = Position.named(
       lat: -33.4312226,
@@ -23,5 +26,102 @@ main() {
     expect(dist.toStringAsFixed(8), newDist.toStringAsFixed(8));
     expect(end.lng.toStringAsFixed(8), newEnd.lng.toStringAsFixed(8));
     expect(end.lat.toStringAsFixed(8), newEnd.lat.toStringAsFixed(8));
+  });
+
+  test('point bearing 0', () {
+    num testBearing = 0;
+    num testDistance = defaultDistance;
+    Point testStart = Point(
+      coordinates: Position.named(
+        lng: -75,
+        lat: 38.10096062273525,
+      ),
+    );
+    Point testEnd = Point(
+      coordinates: Position.named(
+        lng: -75,
+        lat: 39.000281,
+      ),
+    );
+    Point actualEnd = destination(testStart, testDistance, testBearing);
+    expect(actualEnd.coordinates.lat.toStringAsFixed(6),
+        equals(testEnd.coordinates.lat.toStringAsFixed(6)),
+        reason: 'Destination latitude is incorrect');
+    expect(actualEnd.coordinates.lng.toStringAsFixed(6),
+        equals(testEnd.coordinates.lng.toStringAsFixed(6)),
+        reason: 'Destination longitude is incorrect');
+  });
+
+  test('point bearing 90', () {
+    num testBearing = 90;
+    num testDistance = defaultDistance;
+    Point testStart = Point(
+      coordinates: Position.named(
+        lng: -75,
+        lat: 39,
+      ),
+    );
+    Point testEnd = Point(
+      coordinates: Position.named(
+        lng: -73.842853,
+        lat: 38.994285,
+      ),
+    );
+    Point actualEnd = destination(testStart, testDistance, testBearing);
+    expect(actualEnd.coordinates.lat.toStringAsFixed(6),
+        equals(testEnd.coordinates.lat.toStringAsFixed(6)),
+        reason: 'Destination latitude is incorrect');
+    expect(actualEnd.coordinates.lng.toStringAsFixed(6),
+        equals(testEnd.coordinates.lng.toStringAsFixed(6)),
+        reason: 'Destination longitude is incorrect');
+  });
+
+  test('point bearing 180', () {
+    num testBearing = defaultBearing;
+    num testDistance = defaultDistance;
+    Point testStart = Point(
+      coordinates: Position.named(
+        lng: -75,
+        lat: 39,
+      ),
+    );
+    Point testEnd = Point(
+      coordinates: Position.named(
+        lng: -75,
+        lat: 38.10068,
+      ),
+    );
+    Point actualEnd = destination(testStart, testDistance, testBearing);
+    expect(actualEnd.coordinates.lat.toStringAsFixed(6),
+        equals(testEnd.coordinates.lat.toStringAsFixed(6)),
+        reason: 'Destination latitude is incorrect');
+    expect(actualEnd.coordinates.lng.toStringAsFixed(6),
+        equals(testEnd.coordinates.lng.toStringAsFixed(6)),
+        reason: 'Destination longitude is incorrect');
+  });
+
+  test('point 5000 miles away bearing 90', () {
+    num testBearing = 90;
+    num testDistanceMiles = 5000;
+    Point testStart = Point(
+      coordinates: Position.named(
+        lng: -75,
+        lat: 39,
+      ),
+    );
+    Point testEnd = Point(
+      coordinates: Position.named(
+        lng: -22.885356,
+        lat: 26.440011,
+      ),
+    );
+    Point actualEnd =
+        destination(testStart, testDistanceMiles, testBearing, Unit.miles);
+    expect(actualEnd.coordinates.lat.toStringAsFixed(6),
+        equals(testEnd.coordinates.lat.toStringAsFixed(6)),
+        reason: 'Destination latitude is incorrect');
+    expect(actualEnd.coordinates.lng.toStringAsFixed(6),
+        equals(testEnd.coordinates.lng.toStringAsFixed(6)),
+        reason: 'Destination longitude is incorrect');
   });
 }

--- a/test/components/helpers_test.dart
+++ b/test/components/helpers_test.dart
@@ -1,0 +1,82 @@
+import 'dart:math';
+import 'package:test/test.dart';
+import 'package:turf/helpers.dart';
+
+main() {
+  test('radiansToLength', () {
+    expect(radiansToLength(1, Unit.radians), equals(1));
+    expect(radiansToLength(1, Unit.kilometers), equals(earthRadius / 1000));
+    expect(radiansToLength(1, Unit.miles), equals(earthRadius / 1609.344));
+  });
+
+  test('lengthToRadians', () {
+    expect(lengthToRadians(1, Unit.radians), equals(1));
+    expect(lengthToRadians(earthRadius / 1000, Unit.kilometers), equals(1));
+    expect(lengthToRadians(earthRadius / 1609.344, Unit.miles), equals(1));
+  });
+
+  test('lengthToDegrees', () {
+    expect(lengthToDegrees(1, Unit.radians), equals(57.29577951308232));
+    expect(lengthToDegrees(100, Unit.kilometers), equals(0.899320363724538));
+    expect(lengthToDegrees(10, Unit.miles), equals(0.1447315831437903));
+  });
+
+  test('radiansToDegrees', () {
+    expect(round(radiansToDegrees(pi / 3), 6), equals(60),
+        reason: 'radiance conversion pi/3');
+    expect(radiansToDegrees(3.5 * pi), equals(270),
+        reason: 'radiance conversion 3.5pi');
+    expect(radiansToDegrees(-pi), equals(-180),
+        reason: 'radiance conversion -pi');
+  });
+
+  test('radiansToDegrees', () {
+    expect(degreesToRadians(60), equals(pi / 3),
+        reason: 'degrees conversion 60');
+    expect(degreesToRadians(270), equals(1.5 * pi),
+        reason: 'degrees conversion 270');
+    expect(degreesToRadians(-180), equals(-pi),
+        reason: 'degrees conversion -180');
+  });
+
+  test('bearingToAzimuth', () {
+    expect(bearingToAzimuth(40), equals(40));
+    expect(bearingToAzimuth(-105), equals(255));
+    expect(bearingToAzimuth(410), equals(50));
+    expect(bearingToAzimuth(-200), equals(160));
+    expect(bearingToAzimuth(-395), equals(325));
+  });
+
+  test('round', () {
+    expect(round(125.123), equals(125));
+    expect(round(123.123, 1), equals(123.1));
+    expect(round(123.5), equals(124));
+
+    // TODO how to test these expected throw tests
+    // t.throws(() => round(34.5, 'precision'), 'invalid precision');
+    // t.throws(() => round(34.5, -5), 'invalid precision');
+  });
+
+  test('convertLength', () {
+    expect(convertLength(1000, Unit.meters), equals(1));
+    expect(convertLength(1, Unit.kilometers, Unit.miles),
+        equals(0.621371192237334));
+    expect(convertLength(1, Unit.miles, Unit.kilometers), equals(1.609344));
+    expect(convertLength(1, Unit.nauticalmiles), equals(1.852));
+    expect(convertLength(1, Unit.meters, Unit.centimeters),
+        equals(100.00000000000001));
+  });
+
+  test('convertArea', () {
+    expect(convertArea(1000), equals(0.001));
+    expect(convertArea(1, Unit.kilometers, Unit.miles), equals(0.386));
+    expect(convertArea(1, Unit.miles, Unit.kilometers),
+        equals(2.5906735751295336));
+    expect(convertArea(1, Unit.meters, Unit.centimeters), equals(10000));
+    expect(convertArea(100, Unit.meters, Unit.acres), equals(0.0247105));
+    expect(
+        convertArea(100, Unit.meters, Unit.yards), equals(119.59900459999999));
+    expect(convertArea(100, Unit.meters, Unit.feet), equals(1076.3910417));
+    expect(convertArea(100000, Unit.feet), equals(0.009290303999749462));
+  });
+}

--- a/test/components/midpoint_test.dart
+++ b/test/components/midpoint_test.dart
@@ -44,6 +44,8 @@ main() {
     Point result = midpoint(pt1, pt2);
 
     checkLatLngInRange(result);
+    expect(distance(pt1, result).toStringAsFixed(6),
+        equals(distance(pt2, result).toStringAsFixed(6)));
   });
 
   test('midpoint -- vertical from equator', () {
@@ -63,10 +65,8 @@ main() {
     Point result = midpoint(pt1, pt2);
 
     checkLatLngInRange(result);
-    expect(
-        distance(pt1, result).toStringAsFixed(6) ==
-            distance(pt2, result).toStringAsFixed(6),
-        true);
+    expect(distance(pt1, result).toStringAsFixed(6),
+        equals(distance(pt2, result).toStringAsFixed(6)));
   });
 
   test('midpoint -- vertical to equator', () {
@@ -86,10 +86,8 @@ main() {
     Point result = midpoint(pt1, pt2);
 
     checkLatLngInRange(result);
-    expect(
-        distance(pt1, result).toStringAsFixed(6) ==
-            distance(pt2, result).toStringAsFixed(6),
-        true);
+    expect(distance(pt1, result).toStringAsFixed(6),
+        equals(distance(pt2, result).toStringAsFixed(6)));
   });
 
   test('midpoint -- diagonal back over equator', () {
@@ -109,10 +107,8 @@ main() {
     Point result = midpoint(pt1, pt2);
 
     checkLatLngInRange(result);
-    expect(
-        distance(pt1, result).toStringAsFixed(6) ==
-            distance(pt2, result).toStringAsFixed(6),
-        true);
+    expect(distance(pt1, result).toStringAsFixed(6),
+        equals(distance(pt2, result).toStringAsFixed(6)));
   });
 
   test('midpoint -- diagonal forward over equator', () {
@@ -128,10 +124,8 @@ main() {
     Position result = midpointRaw(pt1, pt2);
 
     checkLatLngInRange(Point(coordinates: result.toSigned()));
-    expect(
-        distanceRaw(pt1, result).toStringAsFixed(6) ==
-            distanceRaw(pt2, result).toStringAsFixed(6),
-        true);
+    expect(distanceRaw(pt1, result).toStringAsFixed(6),
+        equals(distanceRaw(pt2, result).toStringAsFixed(6)));
   });
 
   test('midpoint -- long distance', () {
@@ -151,9 +145,7 @@ main() {
     Point result = midpoint(pt1, pt2);
 
     checkLatLngInRange(result);
-    expect(
-        distance(pt1, result).toStringAsFixed(6) ==
-            distance(pt2, result).toStringAsFixed(6),
-        true);
+    expect(distance(pt1, result).toStringAsFixed(6),
+        equals(distance(pt2, result).toStringAsFixed(6)));
   });
 }


### PR DESCRIPTION
Adds ported tests for `destination` and for a few of the `helpers` functions.

Also changes places that used the `%` dart modulo operator to use `num.remainder()` instead, which matches the javascript implementation of turf.js.

Still todo (perhaps in later merge request?):

- [ ] Longitude normalization Position.toSigned fails for miniscule precision mismatch
- [ ] point 5000 miles away bearing 90 fails (seems to get a bearing in the wrong direction)
- [ ] Longitude normalization BBox.toSigned fails for miniscule precision mismatch

I'm going to port some more tests to the geoJson library in another merge request I think.