### PR TITLE
Add fields to all geojson entities

### DIFF
--- a/lib/src/geojson.dart
+++ b/lib/src/geojson.dart
@@ -1,10 +1,6 @@
 import 'package:json_annotation/json_annotation.dart';
 part 'geojson.g.dart';
 
-//TODO assemble multipoint from points
-//TODO assemble multilinestring from linestring
-//TODO assemble polygon from 3 or more points
-
 class GeoJSONObjectTypes {
   static const String point = 'Point';
   static const String multiPoint = 'MultiPoint';


### PR DESCRIPTION
Just `Feature`s can have additional JSON properties than those prescribed by the RFC standard (bbox, geometry, ...). For the other GeoJSON elements, these additional fields are ignored by the JSON deserialization.

The idea is, to deserialize those optional fields for the other elements (`FeatureCollection`, `Polygon`, `Point`, ...) too.

https://github.com/dartclub/turf_dart/blob/6b444bfff9e8500ab2ce8d18e19bb37c8b70b35c/lib/src/geojson.dart#L434
