### PR TITLE
[meta] add implementation and test for featureEach and propEach

### DIFF
--- a/lib/src/meta.dart
+++ b/lib/src/meta.dart
@@ -99,3 +99,69 @@ void _forEachGeomInGeometryObject(
     throw Exception('Unknown Geometry Type');
   }
 }
+
+/// Callback for propEach
+typedef PropEachCallback = dynamic Function(
+    Map<String, dynamic>? currentProperties, num featureIndex);
+
+/// Iterate over properties in any [geoJSON] object, calling [callback] on each
+/// iteration. Similar to Array.forEach()
+///
+/// For example:
+///
+/// ```dart
+/// FeatureCollection featureCollection = FeatureCollection(
+///   features: [
+///     point1,
+///     point2,
+///     point3,
+///   ],
+/// );
+/// propEach(featureCollection, (currentProperties, featureIndex) {
+///   someOperationOnEachProperty(currentProperties);
+/// });
+/// ```
+void propEach(GeoJSONObject geoJSON, PropEachCallback callback) {
+  if (geoJSON is FeatureCollection) {
+    for (var i = 0; i < geoJSON.features.length; i++) {
+      if (callback(geoJSON.features[i].properties, i) == false) break;
+    }
+  } else if (geoJSON is Feature) {
+    callback(geoJSON.properties, 0);
+  } else {
+    throw Exception('Unknown Feature/FeatureCollection Type');
+  }
+}
+
+/// Callback for featureEach
+typedef FeatureEachCallback = dynamic Function(
+    Feature currentFeature, num featureIndex);
+
+/// Iterate over features in any [geoJSON] object, calling [callback] on each
+/// iteration. Similar to Array.forEach.
+///
+/// For example:
+///
+/// ```dart
+/// FeatureCollection featureCollection = FeatureCollection(
+///   features: [
+///     point1,
+///     point2,
+///     point3,
+///   ],
+/// );
+/// featureEach(featureCollection, (currentFeature, featureIndex) {
+///   someOperationOnEachFeature(currentFeature);
+/// });
+/// ```
+void featureEach(GeoJSONObject geoJSON, FeatureEachCallback callback) {
+  if (geoJSON is Feature) {
+    callback(geoJSON, 0);
+  } else if (geoJSON is FeatureCollection) {
+    for (var i = 0; i < geoJSON.features.length; i++) {
+      if (callback(geoJSON.features[i], i) == false) break;
+    }
+  } else {
+    throw Exception('Unknown Feature/FeatureCollection Type');
+  }
+}

--- a/test/components/meta_test.dart
+++ b/test/components/meta_test.dart
@@ -41,6 +41,16 @@ Feature<GeometryCollection> geomCollection = Feature<GeometryCollection>(
     ],
   ),
 );
+
+List<GeoJSONObject> collection(Feature feature) {
+  FeatureCollection featureCollection = FeatureCollection(
+    features: [
+      feature,
+    ],
+  );
+  return [feature, featureCollection];
+}
+
 List<GeoJSONObject> featureAndCollection(GeometryObject geometry) {
   Feature feature = Feature(
     geometry: geometry,
@@ -57,6 +67,66 @@ List<GeoJSONObject> featureAndCollection(GeometryObject geometry) {
 }
 
 main() {
+  test('propEach --featureCollection', () {
+    collection(pt).forEach((input) {
+      propEach(input, (prop, i) {
+        expect(prop, {'a': 1});
+        expect(i, 0);
+      });
+    });
+  });
+
+  test('propEach --feature', () {
+    propEach(pt, (prop, i) {
+      expect(prop, {'a': 1});
+      expect(i, 0);
+    });
+  });
+
+  test('propEach --breaking of iterations', () {
+    var count = 0;
+    propEach(multiline, (prop, i) {
+      count += 1;
+      return false;
+    });
+    expect(count, 1);
+  });
+
+  test('featureEach --featureCollection', () {
+    collection(pt).forEach((input) {
+      featureEach(input, (feature, i) {
+        expect(feature.properties, {'a': 1});
+        expect(
+            feature.geometry,
+            Point.fromJson({
+              'coordinates': [0, 0],
+            }));
+        expect(i, 0);
+      });
+    });
+  });
+
+  test('featureEach --feature', () {
+    featureEach(pt, (feature, i) {
+      expect(feature.properties, {'a': 1});
+      expect(
+          feature.geometry,
+          Point.fromJson({
+            'coordinates': [0, 0],
+          }));
+      expect(i, 0);
+    });
+  });
+
+  test('featureEach --breaking of iterations', () {
+    var count = 0;
+    featureEach(multiline, (feature, i) {
+      count += 1;
+      return false;
+    });
+    expect(count, 1);
+  });
+
   test('geomEach -- GeometryCollection', () {
     featureAndCollection(geomCollection.geometry!)
         .forEach((GeoJSONObject input) {


### PR DESCRIPTION
This PR adds implementation for [propEach](https://github.com/Turfjs/turf/blob/master/packages/turf-meta/index.js#L268-L306) and [featureEach](https://github.com/Turfjs/turf/blob/master/packages/turf-meta/index.js#L363-L398). Setup and docs are conform to #13. For testing, I ported the propEach test from turf.js [here](https://github.com/Turfjs/turf/blob/master/packages/turf-meta/test.js#L125-L133). For featureEach there is no dedicated test. After this PR lands, will look at `coordEach` which unlocks many other non meta functionality.