### PR TITLE
[meta] add coordeach implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,9 @@ Any new benchmarks must be named `*_benchmark.dart` and reside in the
 
 ### META
 - [ ] coordAll
-- [ ] coordEach
+- [x] coordEach
 - [ ] coordReduce
-- [ ] featureEach
+- [x] featureEach
 - [ ] featureReduce
 - [ ] flattenEach
 - [ ] flattenReduce
@@ -137,9 +137,9 @@ Any new benchmarks must be named `*_benchmark.dart` and reside in the
 - [ ] getCoords
 - [ ] getGeom
 - [ ] getType
-- [ ] geomEach
+- [x] geomEach
 - [ ] geomReduce
-- [ ] propEach
+- [x] propEach
 - [ ] propReduce
 - [ ] segmentEach
 - [ ] segmentReduce

--- a/benchmark/meta_benchmark.dart
+++ b/benchmark/meta_benchmark.dart
@@ -2,6 +2,9 @@ import 'package:benchmark/benchmark.dart';
 import 'package:turf/helpers.dart';
 import 'package:turf/meta.dart';
 
+import 'dart:convert';
+import 'dart:io';
+
 void main() {
   Point pt = Point.fromJson({
     'coordinates': [0, 0]
@@ -49,6 +52,17 @@ void main() {
     benchmark('feature collection', () {
       coordEach(featureCollection, coordEachNoopCB);
     });
+
+    var dir = Directory('./test/examples');
+    for (var file in dir.listSync(recursive: true)) {
+      if (file is File && file.path.endsWith('.geojson')) {
+        var source = (file).readAsStringSync();
+        var geoJSON = GeoJSONObject.fromJson(jsonDecode(source));
+        benchmark(file.path, () {
+          coordEach(geoJSON, coordEachNoopCB);
+        });
+      }
+    }
   });
 
   group('geomEach', () {

--- a/benchmark/meta_benchmark.dart
+++ b/benchmark/meta_benchmark.dart
@@ -25,6 +25,32 @@ void main() {
     features: pointFeatures,
   );
 
+  group('coordEach', () {
+    void coordEachNoopCB(
+      CoordinateType? currentCoord,
+      int? coordIndex,
+      int? featureIndex,
+      int? multiFeatureIndex,
+      int? geometryIndex,
+    ) {}
+
+    benchmark('geometry', () {
+      coordEach(pt, coordEachNoopCB);
+    });
+
+    benchmark('feature', () {
+      coordEach(featurePt, coordEachNoopCB);
+    });
+
+    benchmark('geometry collection', () {
+      coordEach(geomCollection, coordEachNoopCB);
+    });
+
+    benchmark('feature collection', () {
+      coordEach(featureCollection, coordEachNoopCB);
+    });
+  });
+
   group('geomEach', () {
     void geomEachNoopCB(
       GeometryObject? currentGeometry,

--- a/lib/src/meta.dart
+++ b/lib/src/meta.dart
@@ -1,5 +1,149 @@
 import 'geojson.dart';
 
+typedef CoordEachCallback = dynamic Function(
+  CoordinateType? currentCoord,
+  int? coordIndex,
+  int? featureIndex,
+  int? multiFeatureIndex,
+  int? geometryIndex,
+);
+
+///
+/// Iterate over coordinates in any [geoJSON] object, similar to Array.forEach()
+///
+/// For example:
+///
+/// ```dart
+/// // TODO add example
+/// ```
+void coordEach(GeoJSONObject geoJSON, CoordEachCallback callback,
+    [bool excludeWrapCoord = false]) {
+  dynamic coords;
+  dynamic geometry;
+  int stopG;
+  GeoJSONObject? geometryMaybeCollection;
+  int wrapShrink = 0;
+  int coordIndex = 0;
+  bool isGeometryCollection;
+  bool isFeatureCollection = geoJSON is FeatureCollection;
+  bool isFeature = geoJSON is Feature;
+  int stop = isFeatureCollection ? geoJSON.features.length : 1;
+
+  try {
+    for (var featureIndex = 0; featureIndex < stop; featureIndex++) {
+      geometryMaybeCollection = isFeatureCollection
+          ? geoJSON.features[featureIndex].geometry
+          : isFeature
+              ? geoJSON.geometry
+              : geoJSON;
+
+      isGeometryCollection = geometryMaybeCollection != null
+          ? geometryMaybeCollection is GeometryCollection
+          : false;
+
+      stopG =
+          isGeometryCollection ? geometryMaybeCollection.geometries.length : 1;
+
+      for (int geomIndex = 0; geomIndex < stopG; geomIndex++) {
+        int multiFeatureIndex = 0;
+        int geometryIndex = 0;
+        geometry = isGeometryCollection
+            ? geometryMaybeCollection.geometries[geomIndex]
+            : geometryMaybeCollection;
+
+        // Handles null Geometry -- Skips this geometry
+        if (geometry == null) {
+          continue;
+        }
+        coords = geometry.coordinates as Iterable;
+        GeoJSONObjectType geomType = geometry.type;
+
+        wrapShrink = excludeWrapCoord &&
+                (geomType == GeoJSONObjectType.polygon ||
+                    geomType == GeoJSONObjectType.multiLineString)
+            ? 1
+            : 0;
+
+        if (geomType == GeoJSONObjectType.point) {
+          if (callback(coords as CoordinateType, coordIndex, featureIndex,
+                  multiFeatureIndex, geometryIndex) ==
+              false) {
+            throw _ShortCircuit();
+          }
+          coordIndex++;
+          multiFeatureIndex++;
+          break;
+        } else if (geomType == GeoJSONObjectType.lineString ||
+            geomType == GeoJSONObjectType.multiPoint) {
+          for (var j = 0; j < coords.length; j++) {
+            if (callback(coords[j], coordIndex, featureIndex, multiFeatureIndex,
+                    geometryIndex) ==
+                false) {
+              throw _ShortCircuit();
+            }
+            coordIndex++;
+            if (geomType == GeoJSONObjectType.multiPoint) {
+              multiFeatureIndex++;
+            }
+          }
+          if (geomType == GeoJSONObjectType.lineString) {
+            multiFeatureIndex++;
+          }
+        } else if (geomType == GeoJSONObjectType.polygon ||
+            geomType == GeoJSONObjectType.multiLineString) {
+          for (var j = 0; j < coords.length; j++) {
+            for (var k = 0; k < coords[j].length - wrapShrink; k++) {
+              if (callback(coords[j][k], coordIndex, featureIndex,
+                      multiFeatureIndex, geometryIndex) ==
+                  false) {
+                throw _ShortCircuit();
+              }
+              coordIndex++;
+            }
+            if (geomType == GeoJSONObjectType.multiLineString) {
+              multiFeatureIndex++;
+            }
+            if (geomType == GeoJSONObjectType.polygon) {
+              geometryIndex++;
+            }
+          }
+          if (geomType == GeoJSONObjectType.polygon) {
+            multiFeatureIndex++;
+          }
+        } else if (geomType == GeoJSONObjectType.multiPolygon) {
+          for (var j = 0; j < coords.length; j++) {
+            geometryIndex = 0;
+            for (var k = 0; k < coords[j].length; k++) {
+              for (var l = 0; l < coords[j][k].length - wrapShrink; l++) {
+                if (callback(coords[j][k][l], coordIndex, featureIndex,
+                        multiFeatureIndex, geometryIndex) ==
+                    false) {
+                  throw _ShortCircuit();
+                }
+                coordIndex++;
+              }
+              geometryIndex++;
+            }
+            multiFeatureIndex++;
+          }
+        } else if (geomType == GeoJSONObjectType.geometryCollection) {
+          for (var j = 0; j < geometry.geometries.length; j++) {
+            try {
+              coordEach(geometry.geometries[j], callback, excludeWrapCoord);
+            } on _ShortCircuit {
+              rethrow;
+            }
+          }
+        } else {
+          throw Exception('Unknown Geometry Type');
+        }
+      }
+    }
+  } on _ShortCircuit {
+    return;
+  }
+}
+
 typedef GeomEachCallback = dynamic Function(
   GeometryObject? currentGeometry,
   int? featureIndex,

--- a/test/components/meta_test.dart
+++ b/test/components/meta_test.dart
@@ -10,6 +10,7 @@ Feature<Point> pt = Feature<Point>(
     'a': 1,
   },
 );
+
 Feature<LineString> line = Feature<LineString>(
   geometry: LineString.fromJson({
     'coordinates': [
@@ -18,6 +19,41 @@ Feature<LineString> line = Feature<LineString>(
     ]
   }),
 );
+
+Feature<Polygon> poly = Feature<Polygon>(
+  geometry: Polygon.fromJson({
+    'coordinates': [
+      [
+        [0, 0],
+        [1, 1],
+        [0, 1],
+        [0, 0],
+      ],
+    ]
+  }),
+);
+
+Feature<Polygon> polyWithHole = Feature<Polygon>(
+  geometry: Polygon.fromJson({
+    'coordinates': [
+      [
+        [100.0, 0.0],
+        [101.0, 0.0],
+        [101.0, 1.0],
+        [100.0, 1.0],
+        [100.0, 0.0],
+      ],
+      [
+        [100.2, 0.2],
+        [100.8, 0.2],
+        [100.8, 0.8],
+        [100.2, 0.8],
+        [100.2, 0.2],
+      ],
+    ]
+  }),
+);
+
 Feature<MultiLineString> multiline = Feature<MultiLineString>(
   geometry: MultiLineString.fromJson({
     'coordinates': [
@@ -32,6 +68,30 @@ Feature<MultiLineString> multiline = Feature<MultiLineString>(
     ],
   }),
 );
+
+Feature<MultiPolygon> multiPoly = Feature<MultiPolygon>(
+  geometry: MultiPolygon.fromJson({
+    'coordinates': [
+      [
+        [
+          [0, 0],
+          [1, 1],
+          [0, 1],
+          [0, 0],
+        ],
+      ],
+      [
+        [
+          [3, 3],
+          [2, 2],
+          [1, 2],
+          [3, 3],
+        ],
+      ],
+    ]
+  }),
+);
+
 Feature<GeometryCollection> geomCollection = Feature<GeometryCollection>(
   geometry: GeometryCollection(
     geometries: [
@@ -41,6 +101,36 @@ Feature<GeometryCollection> geomCollection = Feature<GeometryCollection>(
     ],
   ),
 );
+
+FeatureCollection fcMixed = FeatureCollection(features: [
+  Feature<Point>(
+    geometry: Point.fromJson({
+      'coordinates': [0, 0],
+    }),
+  ),
+  Feature<LineString>(
+    geometry: LineString.fromJson({
+      'coordinates': [
+        [1, 1],
+        [2, 2],
+      ]
+    }),
+  ),
+  Feature<MultiLineString>(
+    geometry: MultiLineString.fromJson({
+      'coordinates': [
+        [
+          [1, 1],
+          [0, 0],
+        ],
+        [
+          [4, 4],
+          [5, 5],
+        ],
+      ],
+    }),
+  ),
+]);
 
 List<GeoJSONObject> collection(Feature feature) {
   FeatureCollection featureCollection = FeatureCollection(
@@ -67,6 +157,299 @@ List<GeoJSONObject> featureAndCollection(GeometryObject geometry) {
 }
 
 main() {
+  test('coordEach -- Point', () {
+    featureAndCollection(pt.geometry!).forEach((input) {
+      coordEach(input, (currentCoord, coordIndex, featureIndex,
+          multiFeatureIndex, geometryIndex) {
+        expect(currentCoord, [0, 0]);
+        expect(coordIndex, 0);
+        expect(featureIndex, 0);
+        expect(multiFeatureIndex, 0);
+        expect(geometryIndex, 0);
+      });
+    });
+  });
+
+  test('coordEach -- LineString', () {
+    featureAndCollection(line.geometry!).forEach((input) {
+      List<CoordinateType?> output = [];
+      int? lastIndex = 0;
+      coordEach(input, (currentCoord, coordIndex, featureIndex,
+          multiFeatureIndex, geometryIndex) {
+        output.add(currentCoord);
+        lastIndex = coordIndex;
+      });
+      expect(output, [
+        [0, 0],
+        [1, 1]
+      ]);
+      expect(lastIndex, 1);
+    });
+  });
+
+  test('coordEach -- Polygon', () {
+    featureAndCollection(poly.geometry!).forEach((input) {
+      List<CoordinateType?> output = [];
+      int? lastIndex = 0;
+      coordEach(input, (currentCoord, coordIndex, featureIndex,
+          multiFeatureIndex, geometryIndex) {
+        output.add(currentCoord);
+        lastIndex = coordIndex;
+      });
+      expect(output, [
+        [0, 0],
+        [1, 1],
+        [0, 1],
+        [0, 0]
+      ]);
+      expect(lastIndex, 3);
+    });
+  });
+
+  test('coordEach -- Polygon excludeWrapCoord', () {
+    featureAndCollection(poly.geometry!).forEach((input) {
+      List<CoordinateType?> output = [];
+      int? lastIndex = 0;
+      coordEach(input, (currentCoord, coordIndex, featureIndex,
+          multiFeatureIndex, geometryIndex) {
+        output.add(currentCoord);
+        lastIndex = coordIndex;
+      }, true);
+      expect(lastIndex, 2);
+    });
+  });
+
+  test('coordEach -- MultiPolygon', () {
+    List<CoordinateType?> coords = [];
+    List<int?> coordIndexes = [];
+    List<int?> featureIndexes = [];
+    List<int?> multiFeatureIndexes = [];
+    coordEach(multiPoly, (currentCoord, coordIndex, featureIndex,
+        multiFeatureIndex, geometryIndex) {
+      coords.add(currentCoord);
+      coordIndexes.add(coordIndex);
+      featureIndexes.add(featureIndex);
+      multiFeatureIndexes.add(multiFeatureIndex);
+    });
+    expect(coordIndexes, [0, 1, 2, 3, 4, 5, 6, 7]);
+    expect(featureIndexes, [0, 0, 0, 0, 0, 0, 0, 0]);
+    expect(multiFeatureIndexes, [0, 0, 0, 0, 1, 1, 1, 1]);
+    expect(coords.length, 8);
+  });
+
+  test('coordEach -- FeatureCollection', () {
+    List<CoordinateType?> coords = [];
+    List<int?> coordIndexes = [];
+    List<int?> featureIndexes = [];
+    List<int?> multiFeatureIndexes = [];
+    coordEach(fcMixed, (currentCoord, coordIndex, featureIndex,
+        multiFeatureIndex, geometryIndex) {
+      coords.add(currentCoord);
+      coordIndexes.add(coordIndex);
+      featureIndexes.add(featureIndex);
+      multiFeatureIndexes.add(multiFeatureIndex);
+    });
+    expect(coordIndexes, [0, 1, 2, 3, 4, 5, 6]);
+    expect(featureIndexes, [0, 1, 1, 2, 2, 2, 2]);
+    expect(multiFeatureIndexes, [0, 0, 0, 0, 0, 1, 1]);
+    expect(coords.length, 7);
+  });
+
+  test('coordEach -- indexes -- PolygonWithHole', () {
+    List<int?> coordIndexes = [];
+    List<int?> featureIndexes = [];
+    List<int?> multiFeatureIndexes = [];
+    List<int?> geometryIndexes = [];
+    coordEach(polyWithHole, (currentCoord, coordIndex, featureIndex,
+        multiFeatureIndex, geometryIndex) {
+      coordIndexes.add(coordIndex);
+      featureIndexes.add(featureIndex);
+      multiFeatureIndexes.add(multiFeatureIndex);
+      geometryIndexes.add(geometryIndex);
+    });
+    expect(coordIndexes, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    expect(featureIndexes, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    expect(multiFeatureIndexes, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    expect(geometryIndexes, [0, 0, 0, 0, 0, 1, 1, 1, 1, 1]);
+  });
+
+  test('coordEach -- indexes -- Multi-Polygon with hole', () {
+    List<int?> featureIndexes = [];
+    List<int?> multiFeatureIndexes = [];
+    List<int?> geometryIndexes = [];
+    List<int?> coordIndexes = [];
+
+    Feature<MultiPolygon> multiPolyWithHole = Feature<MultiPolygon>(
+      geometry: MultiPolygon.fromJson({
+        'coordinates': [
+          [
+            [
+              [102.0, 2.0],
+              [103.0, 2.0],
+              [103.0, 3.0],
+              [102.0, 3.0],
+              [102.0, 2.0],
+            ],
+          ],
+          [
+            [
+              [100.0, 0.0],
+              [101.0, 0.0],
+              [101.0, 1.0],
+              [100.0, 1.0],
+              [100.0, 0.0],
+            ],
+            [
+              [100.2, 0.2],
+              [100.8, 0.2],
+              [100.8, 0.8],
+              [100.2, 0.8],
+              [100.2, 0.2],
+            ],
+          ],
+        ]
+      }),
+    );
+
+    coordEach(multiPolyWithHole, (currentCoord, coordIndex, featureIndex,
+        multiFeatureIndex, geometryIndex) {
+      coordIndexes.add(coordIndex);
+      featureIndexes.add(featureIndex);
+      multiFeatureIndexes.add(multiFeatureIndex);
+      geometryIndexes.add(geometryIndex);
+    });
+    expect(coordIndexes, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]);
+    expect(featureIndexes, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    expect(multiFeatureIndexes, [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]);
+    expect(geometryIndexes, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1]);
+  });
+
+  test('coordEach -- indexes -- Polygon with hole', () {
+    List<int?> featureIndexes = [];
+    List<int?> multiFeatureIndexes = [];
+    List<int?> geometryIndexes = [];
+    List<int?> coordIndexes = [];
+
+    Feature<Polygon> polygonWithHole = Feature<Polygon>(
+      geometry: Polygon.fromJson({
+        'coordinates': [
+          [
+            [100.0, 0.0],
+            [101.0, 0.0],
+            [101.0, 1.0],
+            [100.0, 1.0],
+            [100.0, 0.0],
+          ],
+          [
+            [100.2, 0.2],
+            [100.8, 0.2],
+            [100.8, 0.8],
+            [100.2, 0.8],
+            [100.2, 0.2],
+          ],
+        ]
+      }),
+    );
+
+    coordEach(polygonWithHole, (currentCoord, coordIndex, featureIndex,
+        multiFeatureIndex, geometryIndex) {
+      coordIndexes.add(coordIndex);
+      featureIndexes.add(featureIndex);
+      multiFeatureIndexes.add(multiFeatureIndex);
+      geometryIndexes.add(geometryIndex);
+    });
+    expect(coordIndexes, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    expect(featureIndexes, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    expect(multiFeatureIndexes, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    expect(geometryIndexes, [0, 0, 0, 0, 0, 1, 1, 1, 1, 1]);
+  });
+
+  test('coordEach -- indexes -- FeatureCollection of LineString', () {
+    List<int?> featureIndexes = [];
+    List<int?> multiFeatureIndexes = [];
+    List<int?> geometryIndexes = [];
+    List<int?> coordIndexes = [];
+
+    FeatureCollection line = FeatureCollection(features: [
+      Feature<LineString>(
+        geometry: LineString.fromJson({
+          'coordinates': [
+            [100.0, 0.0],
+            [101.0, 0.0],
+            [101.0, 1.0],
+            [100.0, 1.0],
+            [100.0, 0.0],
+          ]
+        }),
+      ),
+      Feature<LineString>(
+        geometry: LineString.fromJson({
+          'coordinates': [
+            [100.2, 0.2],
+            [100.8, 0.2],
+            [100.8, 0.8],
+            [100.2, 0.8],
+            [100.2, 0.2],
+          ]
+        }),
+      ),
+    ]);
+
+    coordEach(line, (currentCoord, coordIndex, featureIndex, multiFeatureIndex,
+        geometryIndex) {
+      coordIndexes.add(coordIndex);
+      featureIndexes.add(featureIndex);
+      multiFeatureIndexes.add(multiFeatureIndex);
+      geometryIndexes.add(geometryIndex);
+    });
+    expect(coordIndexes, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    expect(featureIndexes, [0, 0, 0, 0, 0, 1, 1, 1, 1, 1]);
+    expect(multiFeatureIndexes, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    expect(geometryIndexes, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+  });
+
+  test('coordEach -- breaking of iterations - featureCollection', () {
+    var count = 0;
+
+    FeatureCollection lines = FeatureCollection(features: [
+      Feature<LineString>(
+        geometry: LineString.fromJson({
+          'coordinates': [
+            [10, 10],
+            [50, 30],
+            [30, 40],
+          ]
+        }),
+      ),
+      Feature<LineString>(
+        geometry: LineString.fromJson({
+          'coordinates': [
+            [-10, -10],
+            [-50, -30],
+            [-30, -40],
+          ]
+        }),
+      ),
+    ]);
+
+    coordEach(lines, (currentCoord, coordIndex, featureIndex, multiFeatureIndex,
+        geometryIndex) {
+      count += 1;
+      return false;
+    });
+    expect(count, 1);
+  });
+
+  test('coordEach -- breaking of iterations - multiGeometry', () {
+    var count = 0;
+    coordEach(multiline, (currentCoord, coordIndex, featureIndex,
+        multiFeatureIndex, geometryIndex) {
+      count += 1;
+      return false;
+    });
+    expect(count, 1);
+  });
+
   test('propEach --featureCollection', () {
     collection(pt).forEach((input) {
       propEach(input, (prop, i) {


### PR DESCRIPTION
This PR ports the JS implementation of [coordeach](https://github.com/Turfjs/turf/blob/master/packages/turf-meta/index.js#L36) and related [tests](https://github.com/Turfjs/turf/blob/master/packages/turf-meta/test.js#L135).

#### Work remaining:
 - [x] port JS implementation
 - [x] port tests 
 - [ ] adopt approach to be aligned with geomEach (eg. ShortCircuit)
 - [x] support breaking of iteration for geometryCollection
 - [x] update README.md support table

cc @baparham @lukas-h 