### PR TITLE
Meta functions extension methods (attempt 2)

### DIFF
--- a/benchmark/line_segment_benchmark.dart
+++ b/benchmark/line_segment_benchmark.dart
@@ -79,9 +79,16 @@ void main() {
       lineSegment(collection);
     });
     benchmark('segmentReduce', () {
-      segmentReduce(collection, (previousValue, currentSegment, initialValue,
-          featureIndex, multiFeatureIndex, geometryIndex, segmentIndex) {
-        previousValue++;
+      segmentReduce<int>(collection, (previousValue,
+          currentSegment,
+          initialValue,
+          featureIndex,
+          multiFeatureIndex,
+          geometryIndex,
+          segmentIndex) {
+        if (previousValue != null) {
+          previousValue++;
+        }
         return previousValue;
       }, 0, combineNestedGeometries: false);
     });

--- a/lib/extensions.dart
+++ b/lib/extensions.dart
@@ -1,0 +1,3 @@
+library turf_extensions;
+
+export 'src/meta/extensions.dart';

--- a/lib/meta.dart
+++ b/lib/meta.dart
@@ -5,5 +5,5 @@ export 'src/meta/coord.dart';
 export 'src/meta/feature.dart';
 export 'src/meta/flatten.dart';
 export 'src/meta/geom.dart';
-export 'src/line_segment.dart' show segmentEach, segmentReduce;
+export 'src/line_segment.dart' hide lineSegment;
 export 'src/meta/prop.dart';

--- a/lib/src/line_segment.dart
+++ b/lib/src/line_segment.dart
@@ -249,7 +249,7 @@ typedef T? SegmentReduceCallback<T>(
 
 T? segmentReduce<T>(
   GeoJSONObject geojson,
-  SegmentReduceCallback callback,
+  SegmentReduceCallback<T> callback,
   T? initialValue, {
   bool combineNestedGeometries = true,
 }) {

--- a/lib/src/meta/extensions.dart
+++ b/lib/src/meta/extensions.dart
@@ -18,6 +18,10 @@ extension GeoJSONObjectMetaExtension on GeoJSONObject {
     meta.coordEach(this, callback);
   }
 
+  List<Position?> coordAll() {
+    return meta.coordAll(this);
+  }
+
   void flattenEach(meta.FlattenEachCallback callback) {
     meta.flattenEach(this, callback);
   }
@@ -30,5 +34,9 @@ extension GeoJSONObjectMetaExtension on GeoJSONObject {
 extension FeatureCollectionMetaExtension on FeatureCollection {
   void clusterEach(dynamic property, meta.ClusterEachCallback callback) {
     meta.clusterEach(this, property, callback);
+  }
+
+  FeatureCollection getCluster(dynamic filter) {
+    return meta.getCluster(this, filter);
   }
 }

--- a/lib/src/meta/extensions.dart
+++ b/lib/src/meta/extensions.dart
@@ -7,7 +7,11 @@ extension GeoJSONObjectMetaExtension on GeoJSONObject {
   }
 
   T? geomReduce<T>(meta.GeomReduceCallback<T> callback, T? initialValue) {
-    meta.geomReduce<T>(this, callback, initialValue);
+    meta.geomReduce<T>(
+      this,
+      callback,
+      initialValue,
+    );
   }
 
   void propEach(meta.PropEachCallback callback) {
@@ -15,7 +19,6 @@ extension GeoJSONObjectMetaExtension on GeoJSONObject {
   }
 
   T? propReduce<T>(
-    GeoJSONObject geojson,
     meta.PropReduceCallback<T> callback,
     T? initialValue,
   ) {
@@ -31,7 +34,6 @@ extension GeoJSONObjectMetaExtension on GeoJSONObject {
   }
 
   T? featureReduce<T>(
-    GeoJSONObject geojson,
     meta.FeatureReduceCallback<T> callback,
     T? initialValue,
   ) {
@@ -68,7 +70,6 @@ extension GeoJSONObjectMetaExtension on GeoJSONObject {
   }
 
   T? flattenReduce<T>(
-    GeoJSONObject geojson,
     meta.FlattenReduceCallback<T> callback,
     T? initialValue,
   ) {
@@ -98,7 +99,10 @@ extension GeoJSONObjectMetaExtension on GeoJSONObject {
 }
 
 extension FeatureCollectionMetaExtension on FeatureCollection {
-  void clusterEach(dynamic property, meta.ClusterEachCallback callback) {
+  void clusterEach(
+    dynamic property,
+    meta.ClusterEachCallback callback,
+  ) {
     meta.clusterEach(this, property, callback);
   }
 

--- a/lib/src/meta/extensions.dart
+++ b/lib/src/meta/extensions.dart
@@ -6,16 +6,57 @@ extension GeoJSONObjectMetaExtension on GeoJSONObject {
     meta.geomEach(this, callback);
   }
 
+  T? geomReduce<T>(meta.GeomReduceCallback<T> callback, T? initialValue) {
+    meta.geomReduce<T>(this, callback, initialValue);
+  }
+
   void propEach(meta.PropEachCallback callback) {
     meta.propEach(this, callback);
+  }
+
+  T? propReduce<T>(
+    GeoJSONObject geojson,
+    meta.PropReduceCallback<T> callback,
+    T? initialValue,
+  ) {
+    meta.propReduce<T>(
+      this,
+      callback,
+      initialValue,
+    );
   }
 
   void featureEach(meta.FeatureEachCallback callback) {
     meta.featureEach(this, callback);
   }
 
+  T? featureReduce<T>(
+    GeoJSONObject geojson,
+    meta.FeatureReduceCallback<T> callback,
+    T? initialValue,
+  ) {
+    meta.featureReduce<T>(
+      this,
+      callback,
+      initialValue,
+    );
+  }
+
   void coordEach(meta.CoordEachCallback callback) {
     meta.coordEach(this, callback);
+  }
+
+  T? coordReduce<T>(
+    meta.CoordReduceCallback<T> callback,
+    T? initialValue, [
+    bool excludeWrapCoord = false,
+  ]) {
+    meta.coordReduce<T>(
+      this,
+      callback,
+      initialValue,
+      excludeWrapCoord,
+    );
   }
 
   List<Position?> coordAll() {
@@ -26,8 +67,33 @@ extension GeoJSONObjectMetaExtension on GeoJSONObject {
     meta.flattenEach(this, callback);
   }
 
+  T? flattenReduce<T>(
+    GeoJSONObject geojson,
+    meta.FlattenReduceCallback<T> callback,
+    T? initialValue,
+  ) {
+    meta.flattenReduce<T>(
+      this,
+      callback,
+      initialValue,
+    );
+  }
+
   void segmentEach(meta.SegmentEachCallback callback) {
     meta.segmentEach(this, callback);
+  }
+
+  T? segmentReduce<T>(
+    meta.SegmentReduceCallback<T> callback,
+    T? initialValue, {
+    bool combineNestedGeometries = true,
+  }) {
+    meta.segmentReduce<T>(
+      this,
+      callback,
+      initialValue,
+      combineNestedGeometries: combineNestedGeometries,
+    );
   }
 }
 
@@ -38,5 +104,18 @@ extension FeatureCollectionMetaExtension on FeatureCollection {
 
   FeatureCollection getCluster(dynamic filter) {
     return meta.getCluster(this, filter);
+  }
+
+  T? clusterReduce<T>(
+    dynamic property,
+    meta.ClusterReduceCallback<T> callback,
+    dynamic initialValue,
+  ) {
+    meta.clusterReduce<T>(
+      this,
+      property,
+      callback,
+      initialValue,
+    );
   }
 }

--- a/lib/src/meta/extensions.dart
+++ b/lib/src/meta/extensions.dart
@@ -13,4 +13,22 @@ extension GeoJSONObjectMetaExtension on GeoJSONObject {
   void featureEach(meta.FeatureEachCallback callback) {
     meta.featureEach(this, callback);
   }
+
+  void coordEach(meta.CoordEachCallback callback) {
+    meta.coordEach(this, callback);
+  }
+
+  void flattenEach(meta.FlattenEachCallback callback) {
+    meta.flattenEach(this, callback);
+  }
+
+  void segmentEach(meta.SegmentEachCallback callback) {
+    meta.segmentEach(this, callback);
+  }
+}
+
+extension FeatureCollectionMetaExtension on FeatureCollection {
+  void clusterEach(dynamic property, meta.ClusterEachCallback callback) {
+    meta.clusterEach(this, property, callback);
+  }
 }

--- a/lib/src/meta/extensions.dart
+++ b/lib/src/meta/extensions.dart
@@ -1,0 +1,16 @@
+import 'package:turf/helpers.dart';
+import 'package:turf/meta.dart' as meta;
+
+extension GeoJSONObjectMetaExtension on GeoJSONObject {
+  void geomEach(meta.GeomEachCallback callback) {
+    meta.geomEach(this, callback);
+  }
+
+  void propEach(meta.PropEachCallback callback) {
+    meta.propEach(this, callback);
+  }
+
+  void featureEach(meta.FeatureEachCallback callback) {
+    meta.featureEach(this, callback);
+  }
+}

--- a/test/components/line_segment_test.dart
+++ b/test/components/line_segment_test.dart
@@ -112,14 +112,16 @@ main() {
   });
 
   test("segmentReduce", () {
-    var total = segmentReduce(poly1, (previousValue,
+    var total = segmentReduce<int>(poly1, (previousValue,
         currentSegment,
         initialValue,
         featureIndex,
         multiFeatureIndex,
         geometryIndex,
         segmentIndex) {
-      previousValue++;
+      if (previousValue != null) {
+        previousValue++;
+      }
       return previousValue;
     }, 0, combineNestedGeometries: false);
     expect(total, 6);


### PR DESCRIPTION
old attempt was this: #52; as discussed here: #12 

*each
- [x] coordEach
- [x] featureEach
- [x] flattenEach
- [x] clusterEach
- [x] segmentEach
- [x] geomEach
- [x] propEach

*reduce
- [x]  featureReduce
- [x] flattenReduce
- [x] clusterReduce
- [x] coordReduce
- [x] propReduce
- [x] geomReduce
- [x] segmentReduce

other
- [x] coordAll
- [x] getCluster