### PR TITLE
Add missing parameter 'unit'.

### DIFF
--- a/lib/src/nearest_point_on_line.dart
+++ b/lib/src/nearest_point_on_line.dart
@@ -163,7 +163,7 @@ _NearestMulti? _nearestPointOnMultiLine(
   for (var i = 0; i < lines.coordinates.length; ++i) {
     final line = LineString(coordinates: lines.coordinates[i]);
 
-    final candidate = _nearestPointOnLine(line, point);
+    final candidate = _nearestPointOnLine(line, point, unit);
 
     if (nearest == null || candidate.distance < nearest.distance) {
       nearest = _NearestMulti(


### PR DESCRIPTION
Add missing parameter 'unit' when calling "_nearestPointOnLine" in function "nearestPointOnLine".