### PR TITLE
Implement length and along

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Any new benchmarks must be named `*_benchmark.dart` and reside in the
 
 ### Measurement
 
-- [ ] along
+- [x] [along](https://github.com/dartclub/turf_dart/blob/main/lib/src/along.dart)
 - [x] [area](https://github.com/dartclub/turf_dart/blob/main/lib/src/area.dart)
 - [x] [bbox](https://github.com/dartclub/turf_dart/blob/main/lib/src/bbox.dart)
 - [x] [bboxPolygon](https://github.com/dartclub/turf_dart/blob/main/lib/src/bbox_polygon.dart)

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Any new benchmarks must be named `*_benchmark.dart` and reside in the
 - [x] [destination](https://github.com/dartclub/turf_dart/blob/main/lib/src/destination.dart)
 - [x] [distance](https://github.com/dartclub/turf_dart/blob/main/lib/src/distance.dart)
 - [ ] envelope
-- [ ] length
+- [x] [length](https://github.com/dartclub/turf_dart/blob/main/lib/src/length.dart)
 - [x] [midpoint](https://github.com/dartclub/turf_dart/blob/main/lib/src/midpoint.dart)
 - [ ] pointOnFeature
 - [ ] polygonTangents

--- a/lib/along.dart
+++ b/lib/along.dart
@@ -1,0 +1,3 @@
+library turf_along;
+
+export "src/along.dart";

--- a/lib/length.dart
+++ b/lib/length.dart
@@ -1,0 +1,3 @@
+library turf_length;
+
+export "src/length.dart";

--- a/lib/src/along.dart
+++ b/lib/src/along.dart
@@ -1,0 +1,39 @@
+import 'package:turf/bearing.dart';
+import 'package:turf/destination.dart';
+import 'package:turf/helpers.dart';
+import 'package:turf/src/distance.dart' as measure_distance;
+
+/// Takes a [line] and returns a [Point] at a specified distance along the line.
+Point? along(LineString line, num distance, [Unit unit = Unit.kilometers]) {
+  // Get Coords
+  final coords = line.coordinates;
+  if (distance < 0) {
+    return coords.isNotEmpty ? Point(coordinates: coords.first) : null;
+  }
+  num travelled = 0;
+  for (int i = 0; i < coords.length; i++) {
+    if (distance >= travelled && i == coords.length - 1) {
+      break;
+    } else if (travelled >= distance) {
+      final overshot = distance - travelled;
+      if (overshot == 0) {
+        return Point(coordinates: coords[i]);
+      } else {
+        final direction = bearing(Point(coordinates: coords[i]),
+                Point(coordinates: coords[i - 1])) -
+            180;
+        final interpolated = destination(
+          Point(coordinates: coords[i]),
+          overshot,
+          direction,
+          unit,
+        );
+        return interpolated;
+      }
+    } else {
+      travelled += measure_distance.distance(Point(coordinates: coords[i]),
+          Point(coordinates: coords[i + 1]), unit);
+    }
+  }
+  return Point(coordinates: coords[coords.length - 1]);
+}

--- a/lib/src/along.dart
+++ b/lib/src/along.dart
@@ -2,14 +2,15 @@ import 'package:turf/bearing.dart';
 import 'package:turf/destination.dart';
 import 'package:turf/helpers.dart';
 import 'package:turf/src/distance.dart' as measure_distance;
+import 'package:turf/src/invariant.dart';
 
 /// Takes a [line] and returns a [Point] at a specified [distance] along the line.
 ///
 /// If [distance] is less than 0, the line start point is returned
 /// If [distance] is larger than line length, the end point is returned
-Point? along(LineString line, num distance, [Unit unit = Unit.kilometers]) {
+Point? along(Feature<LineString> line, num distance, [Unit unit = Unit.kilometers]) {
   // Get Coords
-  final coords = line.coordinates;
+  final coords = getCoords(line);
   if (distance < 0) {
     return coords.isNotEmpty ? Point(coordinates: coords.first) : null;
   }

--- a/lib/src/along.dart
+++ b/lib/src/along.dart
@@ -3,7 +3,10 @@ import 'package:turf/destination.dart';
 import 'package:turf/helpers.dart';
 import 'package:turf/src/distance.dart' as measure_distance;
 
-/// Takes a [line] and returns a [Point] at a specified distance along the line.
+/// Takes a [line] and returns a [Point] at a specified [distance] along the line.
+///
+/// If [distance] is less than 0, the line start point is returned
+/// If [distance] is larger than line length, the end point is returned
 Point? along(LineString line, num distance, [Unit unit = Unit.kilometers]) {
   // Get Coords
   final coords = line.coordinates;

--- a/lib/src/along.dart
+++ b/lib/src/along.dart
@@ -1,6 +1,9 @@
+import 'dart:math';
+
 import 'package:turf/bearing.dart';
 import 'package:turf/destination.dart';
 import 'package:turf/helpers.dart';
+import 'package:turf/length.dart';
 import 'package:turf/src/distance.dart' as measure_distance;
 import 'package:turf/src/invariant.dart';
 
@@ -17,7 +20,7 @@ Point along(Feature<LineString> line, num distance,
     throw Exception('line must contain at least one coordinate');
   }
   if (distance < 0) {
-    return Point(coordinates: coords.first);
+    distance = max(0, length(line, unit) + distance);
   }
   num travelled = 0;
   for (int i = 0; i < coords.length; i++) {

--- a/lib/src/along.dart
+++ b/lib/src/along.dart
@@ -9,7 +9,9 @@ import 'package:turf/src/invariant.dart';
 
 /// Takes a [line] and returns a [Point] at a specified [distance] along the line.
 ///
-/// If [distance] is less than 0, the line start point is returned
+/// If [distance] is less than 0, it will count distance along the line from end
+///   to start of line. If negative [distance] overshoots the length of the line,
+///   the start point of the line is returned.
 /// If [distance] is larger than line length, the end point is returned
 /// If [line] have no geometry or coordinates, an Exception is thrown
 Point along(Feature<LineString> line, num distance,

--- a/lib/src/along.dart
+++ b/lib/src/along.dart
@@ -28,22 +28,22 @@ Point along(Feature<LineString> line, num distance,
   for (int i = 0; i < coords.length; i++) {
     if (distance >= travelled && i == coords.length - 1) {
       break;
-    } else if (travelled >= distance) {
+    }
+    if (travelled == distance) {
+      return Point(coordinates: coords[i]);
+    }
+    if (travelled > distance) {
       final overshot = distance - travelled;
-      if (overshot == 0) {
-        return Point(coordinates: coords[i]);
-      } else {
-        final direction = bearing(Point(coordinates: coords[i]),
-                Point(coordinates: coords[i - 1])) -
-            180;
-        final interpolated = destination(
-          Point(coordinates: coords[i]),
-          overshot,
-          direction,
-          unit,
-        );
-        return interpolated;
-      }
+      final direction = bearing(Point(coordinates: coords[i]),
+              Point(coordinates: coords[i - 1])) -
+          180;
+      final interpolated = destination(
+        Point(coordinates: coords[i]),
+        overshot,
+        direction,
+        unit,
+      );
+      return interpolated;
     } else {
       travelled += measure_distance.distance(Point(coordinates: coords[i]),
           Point(coordinates: coords[i + 1]), unit);

--- a/lib/src/along.dart
+++ b/lib/src/along.dart
@@ -8,11 +8,16 @@ import 'package:turf/src/invariant.dart';
 ///
 /// If [distance] is less than 0, the line start point is returned
 /// If [distance] is larger than line length, the end point is returned
-Point? along(Feature<LineString> line, num distance, [Unit unit = Unit.kilometers]) {
+/// If [line] have no geometry or coordinates, an Exception is thrown
+Point along(Feature<LineString> line, num distance,
+    [Unit unit = Unit.kilometers]) {
   // Get Coords
   final coords = getCoords(line);
+  if (coords.isEmpty) {
+    throw Exception('line must contain at least one coordinate');
+  }
   if (distance < 0) {
-    return coords.isNotEmpty ? Point(coordinates: coords.first) : null;
+    return Point(coordinates: coords.first);
   }
   num travelled = 0;
   for (int i = 0; i < coords.length; i++) {

--- a/lib/src/length.dart
+++ b/lib/src/length.dart
@@ -3,22 +3,23 @@ import 'package:turf/helpers.dart';
 import 'package:turf/line_segment.dart';
 
 /// Takes a [line] and measures its length in the specified [unit].
-num? length(Feature<LineString> line, [Unit unit = Unit.kilometers]) {
+num length(Feature<LineString> line, [Unit unit = Unit.kilometers]) {
   return segmentReduce<num>(line, (
-    previousValue,
-    currentSegment,
-    initialValue,
-    featureIndex,
-    multiFeatureIndex,
-    geometryIndex,
-    segmentIndex,
-  ) {
-    final coords = currentSegment.geometry!.coordinates;
-    return previousValue! +
-        distance(
-          Point(coordinates: coords[0]),
-          Point(coordinates: coords[1]),
-          unit,
-        );
-  }, 0.0);
+        previousValue,
+        currentSegment,
+        initialValue,
+        featureIndex,
+        multiFeatureIndex,
+        geometryIndex,
+        segmentIndex,
+      ) {
+        final coords = currentSegment.geometry!.coordinates;
+        return previousValue! +
+            distance(
+              Point(coordinates: coords[0]),
+              Point(coordinates: coords[1]),
+              unit,
+            );
+      }, 0.0) ??
+      0.0;
 }

--- a/lib/src/length.dart
+++ b/lib/src/length.dart
@@ -3,7 +3,7 @@ import 'package:turf/helpers.dart';
 import 'package:turf/line_segment.dart';
 
 /// Takes a [line] and measures its length in the specified [unit].
-num? length(LineString line, [Unit unit = Unit.kilometers]) {
+num? length(Feature<LineString> line, [Unit unit = Unit.kilometers]) {
   return segmentReduce<num>(line, (
     previousValue,
     currentSegment,

--- a/lib/src/length.dart
+++ b/lib/src/length.dart
@@ -1,0 +1,24 @@
+import 'package:turf/distance.dart';
+import 'package:turf/helpers.dart';
+import 'package:turf/line_segment.dart';
+
+/// Takes a [line] and measures its length in the specified [unit].
+num? length(LineString line, [Unit unit = Unit.kilometers]) {
+  return segmentReduce<num>(line, (
+    previousValue,
+    currentSegment,
+    initialValue,
+    featureIndex,
+    multiFeatureIndex,
+    geometryIndex,
+    segmentIndex,
+  ) {
+    final coords = currentSegment.geometry!.coordinates;
+    return previousValue! +
+        distance(
+          Point(coordinates: coords[0]),
+          Point(coordinates: coords[1]),
+          unit,
+        );
+  }, 0.0);
+}

--- a/lib/turf.dart
+++ b/lib/turf.dart
@@ -1,5 +1,6 @@
 library turf;
 
+export 'src/along.dart';
 export 'src/area.dart';
 export 'src/bbox.dart';
 export 'src/bearing.dart';
@@ -9,6 +10,7 @@ export 'src/destination.dart';
 export 'src/distance.dart';
 export 'src/geojson.dart';
 export 'src/helpers.dart';
+export 'src/length.dart';
 export 'src/midpoint.dart';
 export 'src/nearest_point.dart';
 export 'src/polyline.dart';

--- a/test/components/along_test.dart
+++ b/test/components/along_test.dart
@@ -7,22 +7,18 @@ import 'package:turf/length.dart';
 void main() {
   test('along - negative distance along', () {
     final resolvedStartPoint = along(line, -100, Unit.meters);
-    expect(resolvedStartPoint, isNotNull);
-    expect(resolvedStartPoint!.coordinates, equals(start));
+    expect(resolvedStartPoint.coordinates, equals(start));
   });
   test('along - to start point', () {
     final resolvedStartPoint = along(line, 0, Unit.meters);
-    expect(resolvedStartPoint, isNotNull);
-    expect(resolvedStartPoint!.coordinates, equals(start));
+    expect(resolvedStartPoint.coordinates, equals(start));
   });
   test('along - to point between start and via', () {
     final startToViaDistance = distance(
         Point(coordinates: start), Point(coordinates: via), Unit.meters);
-    expect(startToViaDistance, isNotNull);
     expect(startToViaDistance.round(), equals(57));
     final resolvedViaPoint = along(line, startToViaDistance / 2, Unit.meters);
-    expect(resolvedViaPoint, isNotNull);
-    expect(resolvedViaPoint!.coordinates.lat.toStringAsFixed(6),
+    expect(resolvedViaPoint.coordinates.lat.toStringAsFixed(6),
         equals('55.709028'));
     expect(resolvedViaPoint.coordinates.lng.toStringAsFixed(6),
         equals('13.185096'));
@@ -30,44 +26,35 @@ void main() {
   test('along - to via point', () {
     final startToViaDistance = distance(
         Point(coordinates: start), Point(coordinates: via), Unit.meters);
-    expect(startToViaDistance, isNotNull);
     expect(startToViaDistance.round(), equals(57));
     final resolvedViaPoint = along(line, startToViaDistance, Unit.meters);
-    expect(resolvedViaPoint, isNotNull);
-    expect(resolvedViaPoint!.coordinates, equals(via));
+    expect(resolvedViaPoint.coordinates, equals(via));
   });
   test('along - to point between via and end', () {
     final startToViaDistance = distance(
         Point(coordinates: start), Point(coordinates: via), Unit.meters);
     final viaToEndDistance =
         distance(Point(coordinates: via), Point(coordinates: end), Unit.meters);
-    expect(startToViaDistance, isNotNull);
     expect(startToViaDistance.round(), equals(57));
-    expect(viaToEndDistance, isNotNull);
     expect(viaToEndDistance.round(), equals(198));
     final resolvedViaPoint =
         along(line, startToViaDistance + viaToEndDistance / 2, Unit.meters);
-    expect(resolvedViaPoint, isNotNull);
-    expect(resolvedViaPoint!.coordinates.lat.toStringAsFixed(6),
+    expect(resolvedViaPoint.coordinates.lat.toStringAsFixed(6),
         equals('55.708330'));
     expect(resolvedViaPoint.coordinates.lng.toStringAsFixed(6),
         equals('13.186555'));
   });
   test('along - to end point', () {
     final len = length(line, Unit.meters);
-    expect(len, isNotNull);
-    expect(len!.round(), equals(254));
+    expect(len.round(), equals(254));
     final resolvedEndPoint = along(line, len, Unit.meters);
-    expect(resolvedEndPoint, isNotNull);
-    expect(resolvedEndPoint!.coordinates, equals(end));
+    expect(resolvedEndPoint.coordinates, equals(end));
   });
   test('along - beyond end point', () {
     final len = length(line, Unit.meters);
-    expect(len, isNotNull);
-    expect(len!.round(), equals(254));
+    expect(len.round(), equals(254));
     final resolvedEndPoint = along(line, len + 100, Unit.meters);
-    expect(resolvedEndPoint, isNotNull);
-    expect(resolvedEndPoint!.coordinates, equals(end));
+    expect(resolvedEndPoint.coordinates, equals(end));
   });
 }
 

--- a/test/components/along_test.dart
+++ b/test/components/along_test.dart
@@ -9,8 +9,8 @@ void main() {
     final viaToEndDistance =
         distance(Point(coordinates: via), Point(coordinates: end), Unit.meters);
     expect(viaToEndDistance.round(), equals(198));
-    final resolvedStartPoint = along(line, -1 * viaToEndDistance, Unit.meters);
-    expect(resolvedStartPoint.coordinates, equals(start));
+    final resolvedViaPoint = along(line, -1 * viaToEndDistance, Unit.meters);
+    expect(resolvedViaPoint.coordinates, equals(via));
   });
   test('along - to start point', () {
     final resolvedStartPoint = along(line, 0, Unit.meters);

--- a/test/components/along_test.dart
+++ b/test/components/along_test.dart
@@ -1,0 +1,87 @@
+import 'package:test/test.dart';
+import 'package:turf/along.dart';
+import 'package:turf/distance.dart';
+import 'package:turf/helpers.dart';
+import 'package:turf/length.dart';
+
+void main() {
+  test('along - negative distance along', () {
+    final resolvedStartPoint = along(line, -100, Unit.meters);
+    expect(resolvedStartPoint, isNotNull);
+    expect(resolvedStartPoint!.coordinates, equals(start));
+  });
+  test('along - to start point', () {
+    final resolvedStartPoint = along(line, 0, Unit.meters);
+    expect(resolvedStartPoint, isNotNull);
+    expect(resolvedStartPoint!.coordinates, equals(start));
+  });
+  test('along - to point between start and via', () {
+    final startToViaDistance = distance(
+        Point(coordinates: start), Point(coordinates: via), Unit.meters);
+    expect(startToViaDistance, isNotNull);
+    expect(startToViaDistance.round(), equals(57));
+    final resolvedViaPoint = along(line, startToViaDistance / 2, Unit.meters);
+    expect(resolvedViaPoint, isNotNull);
+    expect(resolvedViaPoint!.coordinates.lat.toStringAsFixed(6), equals('55.709028'));
+    expect(resolvedViaPoint.coordinates.lng.toStringAsFixed(6), equals('13.185096'));
+  });
+  test('along - to via point', () {
+    final startToViaDistance = distance(
+        Point(coordinates: start), Point(coordinates: via), Unit.meters);
+    expect(startToViaDistance, isNotNull);
+    expect(startToViaDistance.round(), equals(57));
+    final resolvedViaPoint = along(line, startToViaDistance, Unit.meters);
+    expect(resolvedViaPoint, isNotNull);
+    expect(resolvedViaPoint!.coordinates, equals(via));
+  });
+  test('along - to point between via and end', () {
+    final startToViaDistance = distance(
+        Point(coordinates: start), Point(coordinates: via), Unit.meters);
+    final viaToEndDistance = distance(
+        Point(coordinates: via), Point(coordinates: end), Unit.meters);
+    expect(startToViaDistance, isNotNull);
+    expect(startToViaDistance.round(), equals(57));
+    expect(viaToEndDistance, isNotNull);
+    expect(viaToEndDistance.round(), equals(198));
+    final resolvedViaPoint = along(line, startToViaDistance + viaToEndDistance / 2, Unit.meters);
+    expect(resolvedViaPoint, isNotNull);
+    expect(resolvedViaPoint!.coordinates.lat.toStringAsFixed(6), equals('55.708330'));
+    expect(resolvedViaPoint.coordinates.lng.toStringAsFixed(6), equals('13.186555'));
+  });
+  test('along - to end point', () {
+    final len = length(line, Unit.meters);
+    expect(len, isNotNull);
+    expect(len!.round(), equals(254));
+    final resolvedEndPoint = along(line, len, Unit.meters);
+    expect(resolvedEndPoint, isNotNull);
+    expect(resolvedEndPoint!.coordinates, equals(end));
+  });
+  test('along - beyond end point', () {
+    final len = length(line, Unit.meters);
+    expect(len, isNotNull);
+    expect(len!.round(), equals(254));
+    final resolvedEndPoint = along(line, len + 100, Unit.meters);
+    expect(resolvedEndPoint, isNotNull);
+    expect(resolvedEndPoint!.coordinates, equals(end));
+  });
+}
+
+final start = Position.named(
+  lat: 55.7090430186194,
+  lng: 13.184645393920405,
+);
+final via = Position.named(
+  lat: 55.70901279569489,
+  lng: 13.185546616182755,
+);
+final end = Position.named(
+  lat: 55.70764669578079,
+  lng: 13.187563637197076,
+);
+final line = LineString(
+  coordinates: [
+    start,
+    via,
+    end,
+  ],
+);

--- a/test/components/along_test.dart
+++ b/test/components/along_test.dart
@@ -5,8 +5,11 @@ import 'package:turf/helpers.dart';
 import 'package:turf/length.dart';
 
 void main() {
-  test('along - negative distance along', () {
-    final resolvedStartPoint = along(line, -100, Unit.meters);
+  test('along - negative distance should count backwards', () {
+    final viaToEndDistance =
+        distance(Point(coordinates: via), Point(coordinates: end), Unit.meters);
+    expect(viaToEndDistance.round(), equals(198));
+    final resolvedStartPoint = along(line, -1 * viaToEndDistance, Unit.meters);
     expect(resolvedStartPoint.coordinates, equals(start));
   });
   test('along - to start point', () {

--- a/test/components/along_test.dart
+++ b/test/components/along_test.dart
@@ -83,10 +83,12 @@ final end = Position.named(
   lat: 55.70764669578079,
   lng: 13.187563637197076,
 );
-final line = LineString(
-  coordinates: [
-    start,
-    via,
-    end,
-  ],
+final line = Feature<LineString>(
+  geometry: LineString(
+    coordinates: [
+      start,
+      via,
+      end,
+    ],
+  ),
 );

--- a/test/components/along_test.dart
+++ b/test/components/along_test.dart
@@ -53,6 +53,12 @@ void main() {
     final resolvedEndPoint = along(line, len, Unit.meters);
     expect(resolvedEndPoint.coordinates, equals(end));
   });
+  test('along - to end point - default unit (km)', () {
+    final len = length(line);
+    expect((len * 1000).round(), equals(254));
+    final resolvedEndPoint = along(line, len);
+    expect(resolvedEndPoint.coordinates, equals(end));
+  });
   test('along - beyond end point', () {
     final len = length(line, Unit.meters);
     expect(len.round(), equals(254));

--- a/test/components/along_test.dart
+++ b/test/components/along_test.dart
@@ -22,8 +22,10 @@ void main() {
     expect(startToViaDistance.round(), equals(57));
     final resolvedViaPoint = along(line, startToViaDistance / 2, Unit.meters);
     expect(resolvedViaPoint, isNotNull);
-    expect(resolvedViaPoint!.coordinates.lat.toStringAsFixed(6), equals('55.709028'));
-    expect(resolvedViaPoint.coordinates.lng.toStringAsFixed(6), equals('13.185096'));
+    expect(resolvedViaPoint!.coordinates.lat.toStringAsFixed(6),
+        equals('55.709028'));
+    expect(resolvedViaPoint.coordinates.lng.toStringAsFixed(6),
+        equals('13.185096'));
   });
   test('along - to via point', () {
     final startToViaDistance = distance(
@@ -37,16 +39,19 @@ void main() {
   test('along - to point between via and end', () {
     final startToViaDistance = distance(
         Point(coordinates: start), Point(coordinates: via), Unit.meters);
-    final viaToEndDistance = distance(
-        Point(coordinates: via), Point(coordinates: end), Unit.meters);
+    final viaToEndDistance =
+        distance(Point(coordinates: via), Point(coordinates: end), Unit.meters);
     expect(startToViaDistance, isNotNull);
     expect(startToViaDistance.round(), equals(57));
     expect(viaToEndDistance, isNotNull);
     expect(viaToEndDistance.round(), equals(198));
-    final resolvedViaPoint = along(line, startToViaDistance + viaToEndDistance / 2, Unit.meters);
+    final resolvedViaPoint =
+        along(line, startToViaDistance + viaToEndDistance / 2, Unit.meters);
     expect(resolvedViaPoint, isNotNull);
-    expect(resolvedViaPoint!.coordinates.lat.toStringAsFixed(6), equals('55.708330'));
-    expect(resolvedViaPoint.coordinates.lng.toStringAsFixed(6), equals('13.186555'));
+    expect(resolvedViaPoint!.coordinates.lat.toStringAsFixed(6),
+        equals('55.708330'));
+    expect(resolvedViaPoint.coordinates.lng.toStringAsFixed(6),
+        equals('13.186555'));
   });
   test('along - to end point', () {
     final len = length(line, Unit.meters);

--- a/test/components/length_test.dart
+++ b/test/components/length_test.dart
@@ -3,29 +3,34 @@ import 'package:turf/helpers.dart';
 import 'package:turf/length.dart';
 
 void main() {
-  test('length', () {
-    final start = Position.named(
-      lat: 55.7090430186194,
-      lng: 13.184645393920405,
-    );
-    final via = Position.named(
-      lat: 55.70901279569489,
-      lng: 13.185546616182755,
-    );
-    final end = Position.named(
-      lat: 55.70764669578079,
-      lng: 13.187563637197076,
-    );
-    final line = Feature<LineString>(
-      geometry: LineString(
-        coordinates: [
-          start,
-          via,
-          end,
-        ],
-      ),
-    );
+  test('length - in meters', () {
     final len = length(line, Unit.meters);
     expect(len.round(), equals(254));
   });
+  test('length - default unit (km)', () {
+    final len = length(line);
+    expect((len * 1000).round(), equals(254));
+  });
 }
+
+final start = Position.named(
+  lat: 55.7090430186194,
+  lng: 13.184645393920405,
+);
+final via = Position.named(
+  lat: 55.70901279569489,
+  lng: 13.185546616182755,
+);
+final end = Position.named(
+  lat: 55.70764669578079,
+  lng: 13.187563637197076,
+);
+final line = Feature<LineString>(
+  geometry: LineString(
+    coordinates: [
+      start,
+      via,
+      end,
+    ],
+  ),
+);

--- a/test/components/length_test.dart
+++ b/test/components/length_test.dart
@@ -26,7 +26,6 @@ void main() {
       ),
     );
     final len = length(line, Unit.meters);
-    expect(len, isNotNull);
-    expect(len!.round(), equals(254));
+    expect(len.round(), equals(254));
   });
 }

--- a/test/components/length_test.dart
+++ b/test/components/length_test.dart
@@ -16,12 +16,14 @@ void main() {
       lat: 55.70764669578079,
       lng: 13.187563637197076,
     );
-    final line = LineString(
-      coordinates: [
-        start,
-        via,
-        end,
-      ],
+    final line = Feature<LineString>(
+      geometry: LineString(
+        coordinates: [
+          start,
+          via,
+          end,
+        ],
+      ),
     );
     final len = length(line, Unit.meters);
     expect(len, isNotNull);

--- a/test/components/length_test.dart
+++ b/test/components/length_test.dart
@@ -1,0 +1,30 @@
+import 'package:test/test.dart';
+import 'package:turf/helpers.dart';
+import 'package:turf/length.dart';
+
+void main() {
+  test('length', () {
+    final start = Position.named(
+      lat: 55.7090430186194,
+      lng: 13.184645393920405,
+    );
+    final via = Position.named(
+      lat: 55.70901279569489,
+      lng: 13.185546616182755,
+    );
+    final end = Position.named(
+      lat: 55.70764669578079,
+      lng: 13.187563637197076,
+    );
+    final line = LineString(
+      coordinates: [
+        start,
+        via,
+        end,
+      ],
+    );
+    final len = length(line, Unit.meters);
+    expect(len, isNotNull);
+    expect(len!.round(), equals(254));
+  });
+}


### PR DESCRIPTION
Implements `length()` and `along()` by porting from turf.js.

Tests are included and the `along()` test uses `length()` so therefore I created one PR instead of two. 

One difference to turf.js is that for `along()` the dart implementation has a guard to return first point in case the provided distance is negative, while the turf.js implementation will return a different point than the start.

Related issue: https://github.com/dartclub/turf_dart/issues/152