### PR TITLE
Document properties set by NearestPointOnLine on returned Point

### DIFF
--- a/lib/src/nearest_point_on_line.dart
+++ b/lib/src/nearest_point_on_line.dart
@@ -183,6 +183,13 @@ _NearestMulti? _nearestPointOnMultiLine(
 }
 
 /// Takes a [Point] and a [LineString] and calculates the closest Point on the [LineString].
+///
+/// The properties of returned [Point] will contain three values:
+/// * index: closest point was found on nth line part
+/// * dist: distance between [point] and the closest point on line
+/// * location: distance along the line between start and the closest point.
+///
+/// Example:
 /// ```dart
 /// var line = LineString(
 ///   coordinates: [


### PR DESCRIPTION
This is documented on turf.js docs, but was omitted in turf_dart.

These returned properties are quite handy in some situations and saves you doing a bit extra work to find these data. 