### PR TITLE
fix wrong conversion from meters to yards and from meters to inches

### DIFF
--- a/lib/src/helpers.dart
+++ b/lib/src/helpers.dart
@@ -52,14 +52,14 @@ const factors = <Unit, num>{
   Unit.centimeters: earthRadius * 100,
   Unit.degrees: earthRadius / 111325,
   Unit.feet: earthRadius * 3.28084,
-  Unit.inches: earthRadius * 39.370,
+  Unit.inches: earthRadius * 39.3701,
   Unit.kilometers: earthRadius / 1000,
   Unit.meters: earthRadius,
   Unit.miles: earthRadius / 1609.344,
   Unit.millimeters: earthRadius * 1000,
   Unit.nauticalmiles: earthRadius / 1852,
   Unit.radians: 1,
-  Unit.yards: earthRadius / 1.0936,
+  Unit.yards: earthRadius * 1.0936,
 };
 
 const unitsFactors = <Unit, num>{


### PR DESCRIPTION
1. Fixed wrong conversion for yards
2. Use more precise conversion from meters to inches